### PR TITLE
Add hide buttons until focused configuration option

### DIFF
--- a/custom_components/entity_notes/__init__.py
+++ b/custom_components/entity_notes/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_MAX_NOTE_LENGTH,
     CONF_AUTO_BACKUP,
     CONF_HIDE_BUTTONS_WHEN_EMPTY,
+    CONF_HIDE_BUTTONS_UNTIL_FOCUS,
     CONF_DELETE_NOTES_WITH_ENTITY,
     CONF_DELETE_NOTES_WITH_DEVICE,
     CONF_ENABLE_DEVICE_NOTES,
@@ -29,6 +30,7 @@ from .const import (
     DEFAULT_MAX_NOTE_LENGTH,
     DEFAULT_AUTO_BACKUP,
     DEFAULT_HIDE_BUTTONS_WHEN_EMPTY,
+    DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS,
     DEFAULT_DELETE_NOTES_WITH_ENTITY,
     DEFAULT_DELETE_NOTES_WITH_DEVICE,
     DEFAULT_ENABLE_DEVICE_NOTES,
@@ -62,13 +64,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Entity Notes from a config entry."""
     _LOGGER.info("Setting up Entity Notes integration")
-    
+
     # Get configuration options
     options = entry.options or {}
     debug_logging = options.get(CONF_DEBUG_LOGGING, DEFAULT_DEBUG_LOGGING)
     max_note_length = options.get(CONF_MAX_NOTE_LENGTH, DEFAULT_MAX_NOTE_LENGTH)
     auto_backup = options.get(CONF_AUTO_BACKUP, DEFAULT_AUTO_BACKUP)
     hide_buttons_when_empty = options.get(CONF_HIDE_BUTTONS_WHEN_EMPTY, DEFAULT_HIDE_BUTTONS_WHEN_EMPTY)
+    hide_buttons_until_focus = options.get(CONF_HIDE_BUTTONS_UNTIL_FOCUS, DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS)
     delete_notes_with_entity = options.get(CONF_DELETE_NOTES_WITH_ENTITY, DEFAULT_DELETE_NOTES_WITH_ENTITY)
     delete_notes_with_device = options.get(CONF_DELETE_NOTES_WITH_DEVICE, DEFAULT_DELETE_NOTES_WITH_DEVICE)
     enable_device_notes = options.get(CONF_ENABLE_DEVICE_NOTES, DEFAULT_ENABLE_DEVICE_NOTES)
@@ -175,6 +178,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 CONF_MAX_NOTE_LENGTH: max_note_length,
                 CONF_AUTO_BACKUP: auto_backup,
                 CONF_HIDE_BUTTONS_WHEN_EMPTY: hide_buttons_when_empty,
+                CONF_HIDE_BUTTONS_UNTIL_FOCUS: hide_buttons_until_focus,
                 CONF_DELETE_NOTES_WITH_ENTITY: delete_notes_with_entity,
                 CONF_DELETE_NOTES_WITH_DEVICE: delete_notes_with_device,
                 CONF_ENABLE_DEVICE_NOTES: enable_device_notes,
@@ -278,7 +282,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         _LOGGER.info("Entity Notes integration setup completed successfully")
         return True
-        
+
     except Exception as e:
         _LOGGER.error("Critical error in Entity Notes setup: %s", e)
         return False
@@ -728,6 +732,7 @@ class EntityNotesJSView(HomeAssistantView):
         debug_logging = hass.data[DOMAIN]["config"].get(CONF_DEBUG_LOGGING, False)
         max_note_length = hass.data[DOMAIN]["config"].get(CONF_MAX_NOTE_LENGTH, 200)
         hide_buttons_when_empty = hass.data[DOMAIN]["config"].get(CONF_HIDE_BUTTONS_WHEN_EMPTY, False)
+        hide_buttons_until_focus = hass.data[DOMAIN]["config"].get(CONF_HIDE_BUTTONS_UNTIL_FOCUS, False)
         enable_device_notes = hass.data[DOMAIN]["config"].get(CONF_ENABLE_DEVICE_NOTES, True)
 
         # Get the JavaScript file path
@@ -745,6 +750,7 @@ class EntityNotesJSView(HomeAssistantView):
             js_content = js_content.replace('{{DEBUG_LOGGING}}', str(debug_logging).lower())
             js_content = js_content.replace('{{MAX_NOTE_LENGTH}}', str(max_note_length))
             js_content = js_content.replace('{{HIDE_BUTTONS_WHEN_EMPTY}}', str(hide_buttons_when_empty).lower())
+            js_content = js_content.replace('{{HIDE_BUTTONS_UNTIL_FOCUS}}', str(hide_buttons_until_focus).lower())
             js_content = js_content.replace('{{ENABLE_DEVICE_NOTES}}', str(enable_device_notes).lower())
 
             return web.Response(text=js_content, content_type='application/javascript')

--- a/custom_components/entity_notes/config_flow.py
+++ b/custom_components/entity_notes/config_flow.py
@@ -16,11 +16,13 @@ from .const import (
     CONF_MAX_NOTE_LENGTH,
     CONF_AUTO_BACKUP,
     CONF_HIDE_BUTTONS_WHEN_EMPTY,
+    CONF_HIDE_BUTTONS_UNTIL_FOCUS,
     CONF_DELETE_NOTES_WITH_ENTITY,
     DEFAULT_DEBUG_LOGGING,
     DEFAULT_MAX_NOTE_LENGTH,
     DEFAULT_AUTO_BACKUP,
     DEFAULT_HIDE_BUTTONS_WHEN_EMPTY,
+    DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS,
     DEFAULT_DELETE_NOTES_WITH_ENTITY,
 )
 
@@ -37,13 +39,13 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
-        
+
         # Check if already configured and handle automatic upgrade
         existing_entries = self._async_current_entries()
         if existing_entries and user_input is None:
             # Get current options from existing entry to pre-populate form
             current_options = existing_entries[0].options if existing_entries[0].options else {}
-            
+
             # Show form with upgrade notice for first-time display
             return self.async_show_form(
                 step_id="user",
@@ -65,13 +67,17 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         default=current_options.get(CONF_HIDE_BUTTONS_WHEN_EMPTY, DEFAULT_HIDE_BUTTONS_WHEN_EMPTY)
                     ): bool,
                     vol.Optional(
+                        CONF_HIDE_BUTTONS_UNTIL_FOCUS,
+                        default=current_options.get(CONF_HIDE_BUTTONS_UNTIL_FOCUS, DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS)
+                    ): bool,
+                    vol.Optional(
                         CONF_DELETE_NOTES_WITH_ENTITY,
                         default=current_options.get(CONF_DELETE_NOTES_WITH_ENTITY, DEFAULT_DELETE_NOTES_WITH_ENTITY)
                     ): bool,
                 }),
                 errors=errors,
                 description_placeholders={
-                    "description": "⚠️ Entity Notes is already installed and will be automatically upgraded with your new settings. Your existing notes and data will be preserved during the upgrade process."
+                    "description": "Entity Notes is already installed and will be automatically upgraded with your new settings. Your existing notes and data will be preserved during the upgrade process."
                 },
             )
 
@@ -80,20 +86,20 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             max_length = user_input.get(CONF_MAX_NOTE_LENGTH, DEFAULT_MAX_NOTE_LENGTH)
             if max_length < 50 or max_length > 2000:
                 errors[CONF_MAX_NOTE_LENGTH] = "invalid_max_length"
-            
+
             if not errors:
                 # Handle automatic upgrade of existing installation
                 if existing_entries:
                     try:
                         _LOGGER.info("Automatically upgrading existing Entity Notes installation")
-                        
+
                         # Remove existing entries one by one
                         for entry in existing_entries:
                             _LOGGER.debug(f"Removing existing entry: {entry.entry_id} (title: {entry.title})")
                             await self.hass.config_entries.async_remove(entry.entry_id)
-                        
+
                         _LOGGER.info("Successfully removed existing Entity Notes entries")
-                        
+
                     except Exception as ex:
                         _LOGGER.error(f"Error during Entity Notes upgrade: {ex}")
                         errors["base"] = "upgrade_failed"
@@ -104,17 +110,18 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 vol.Optional(CONF_MAX_NOTE_LENGTH, default=DEFAULT_MAX_NOTE_LENGTH): vol.All(int, vol.Range(min=50, max=2000)),
                                 vol.Optional(CONF_AUTO_BACKUP, default=DEFAULT_AUTO_BACKUP): bool,
                                 vol.Optional(CONF_HIDE_BUTTONS_WHEN_EMPTY, default=DEFAULT_HIDE_BUTTONS_WHEN_EMPTY): bool,
+                                vol.Optional(CONF_HIDE_BUTTONS_UNTIL_FOCUS, default=DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS): bool,
                                 vol.Optional(CONF_DELETE_NOTES_WITH_ENTITY, default=DEFAULT_DELETE_NOTES_WITH_ENTITY): bool,
                             }),
                             errors=errors,
                             description_placeholders={
-                                "description": "❌ Error during upgrade. Please try again or manually remove the existing Entity Notes integration first from Settings > Devices & Services."
+                                "description": "Error during upgrade. Please try again or manually remove the existing Entity Notes integration first from Settings > Devices & Services."
                             },
                         )
 
                 # Create new entry (either fresh install or after successful upgrade)
                 await self.async_set_unique_id(DOMAIN)
-                
+
                 # Create the new entry with user's settings
                 entry_result = self.async_create_entry(
                     title="Entity Notes",
@@ -124,15 +131,16 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MAX_NOTE_LENGTH: max_length,
                         CONF_AUTO_BACKUP: user_input.get(CONF_AUTO_BACKUP, DEFAULT_AUTO_BACKUP),
                         CONF_HIDE_BUTTONS_WHEN_EMPTY: user_input.get(CONF_HIDE_BUTTONS_WHEN_EMPTY, DEFAULT_HIDE_BUTTONS_WHEN_EMPTY),
+                        CONF_HIDE_BUTTONS_UNTIL_FOCUS: user_input.get(CONF_HIDE_BUTTONS_UNTIL_FOCUS, DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS),
                         CONF_DELETE_NOTES_WITH_ENTITY: user_input.get(CONF_DELETE_NOTES_WITH_ENTITY, DEFAULT_DELETE_NOTES_WITH_ENTITY),
                     },
                 )
-                
+
                 if existing_entries:
                     _LOGGER.info("Entity Notes upgrade completed successfully")
                 else:
                     _LOGGER.info("Entity Notes installation completed successfully")
-                
+
                 return entry_result
 
         # Show configuration form for fresh install
@@ -143,6 +151,7 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_MAX_NOTE_LENGTH, default=DEFAULT_MAX_NOTE_LENGTH): vol.All(int, vol.Range(min=50, max=2000)),
                 vol.Optional(CONF_AUTO_BACKUP, default=DEFAULT_AUTO_BACKUP): bool,
                 vol.Optional(CONF_HIDE_BUTTONS_WHEN_EMPTY, default=DEFAULT_HIDE_BUTTONS_WHEN_EMPTY): bool,
+                vol.Optional(CONF_HIDE_BUTTONS_UNTIL_FOCUS, default=DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS): bool,
                 vol.Optional(CONF_DELETE_NOTES_WITH_ENTITY, default=DEFAULT_DELETE_NOTES_WITH_ENTITY): bool,
             }),
             errors=errors,
@@ -161,13 +170,13 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle reconfiguration of the integration."""
         entry = self._get_reconfigure_entry()
         errors = {}
-        
+
         if user_input is not None:
             # Validate input
             max_length = user_input.get(CONF_MAX_NOTE_LENGTH, DEFAULT_MAX_NOTE_LENGTH)
             if max_length < 50 or max_length > 2000:
                 errors[CONF_MAX_NOTE_LENGTH] = "invalid_max_length"
-            
+
             if not errors:
                 return self.async_update_reload_and_abort(
                     entry,
@@ -177,6 +186,7 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MAX_NOTE_LENGTH: max_length,
                         CONF_AUTO_BACKUP: user_input.get(CONF_AUTO_BACKUP, DEFAULT_AUTO_BACKUP),
                         CONF_HIDE_BUTTONS_WHEN_EMPTY: user_input.get(CONF_HIDE_BUTTONS_WHEN_EMPTY, DEFAULT_HIDE_BUTTONS_WHEN_EMPTY),
+                        CONF_HIDE_BUTTONS_UNTIL_FOCUS: user_input.get(CONF_HIDE_BUTTONS_UNTIL_FOCUS, DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS),
                         CONF_DELETE_NOTES_WITH_ENTITY: user_input.get(CONF_DELETE_NOTES_WITH_ENTITY, DEFAULT_DELETE_NOTES_WITH_ENTITY),
                     },
                     reason="reconfigure_successful",
@@ -201,6 +211,10 @@ class EntityNotesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_HIDE_BUTTONS_WHEN_EMPTY,
                     default=current_options.get(CONF_HIDE_BUTTONS_WHEN_EMPTY, DEFAULT_HIDE_BUTTONS_WHEN_EMPTY)
+                ): bool,
+                vol.Optional(
+                    CONF_HIDE_BUTTONS_UNTIL_FOCUS,
+                    default=current_options.get(CONF_HIDE_BUTTONS_UNTIL_FOCUS, DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS)
                 ): bool,
                 vol.Optional(
                     CONF_DELETE_NOTES_WITH_ENTITY,
@@ -230,13 +244,13 @@ class EntityNotesOptionsFlow(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Manage the options."""
         errors = {}
-        
+
         if user_input is not None:
             # Validate input
             max_length = user_input.get(CONF_MAX_NOTE_LENGTH, DEFAULT_MAX_NOTE_LENGTH)
             if max_length < 50 or max_length > 2000:
                 errors[CONF_MAX_NOTE_LENGTH] = "invalid_max_length"
-            
+
             if not errors:
                 # Create the options entry first
                 result = self.async_create_entry(
@@ -246,13 +260,14 @@ class EntityNotesOptionsFlow(config_entries.OptionsFlow):
                         CONF_MAX_NOTE_LENGTH: max_length,
                         CONF_AUTO_BACKUP: user_input.get(CONF_AUTO_BACKUP, DEFAULT_AUTO_BACKUP),
                         CONF_HIDE_BUTTONS_WHEN_EMPTY: user_input.get(CONF_HIDE_BUTTONS_WHEN_EMPTY, DEFAULT_HIDE_BUTTONS_WHEN_EMPTY),
+                        CONF_HIDE_BUTTONS_UNTIL_FOCUS: user_input.get(CONF_HIDE_BUTTONS_UNTIL_FOCUS, DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS),
                         CONF_DELETE_NOTES_WITH_ENTITY: user_input.get(CONF_DELETE_NOTES_WITH_ENTITY, DEFAULT_DELETE_NOTES_WITH_ENTITY),
                     }
                 )
-                
+
                 # Automatically reload the integration to apply the new settings
                 await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-                
+
                 return result
 
         current_options = self.config_entry.options or {}
@@ -274,6 +289,10 @@ class EntityNotesOptionsFlow(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_HIDE_BUTTONS_WHEN_EMPTY,
                     default=current_options.get(CONF_HIDE_BUTTONS_WHEN_EMPTY, DEFAULT_HIDE_BUTTONS_WHEN_EMPTY)
+                ): bool,
+                vol.Optional(
+                    CONF_HIDE_BUTTONS_UNTIL_FOCUS,
+                    default=current_options.get(CONF_HIDE_BUTTONS_UNTIL_FOCUS, DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS)
                 ): bool,
                 vol.Optional(
                     CONF_DELETE_NOTES_WITH_ENTITY,

--- a/custom_components/entity_notes/const.py
+++ b/custom_components/entity_notes/const.py
@@ -1,6 +1,7 @@
 """Constants for Entity Notes component."""
 
 DOMAIN = "entity_notes"
+
 STORAGE_VERSION = 2
 STORAGE_KEY = "entity_notes.notes"
 MAX_NOTE_LENGTH = 200
@@ -10,6 +11,7 @@ CONF_DEBUG_LOGGING = "debug_logging"
 CONF_MAX_NOTE_LENGTH = "max_note_length"
 CONF_AUTO_BACKUP = "auto_backup"
 CONF_HIDE_BUTTONS_WHEN_EMPTY = "hide_buttons_when_empty"
+CONF_HIDE_BUTTONS_UNTIL_FOCUS = "hide_buttons_until_focus"  # NEW
 CONF_DELETE_NOTES_WITH_ENTITY = "delete_notes_with_entity"
 CONF_DELETE_NOTES_WITH_DEVICE = "delete_notes_with_device"
 CONF_ENABLE_DEVICE_NOTES = "enable_device_notes"
@@ -37,6 +39,7 @@ DEFAULT_DEBUG_LOGGING = False
 DEFAULT_MAX_NOTE_LENGTH = 200
 DEFAULT_AUTO_BACKUP = True
 DEFAULT_HIDE_BUTTONS_WHEN_EMPTY = True
+DEFAULT_HIDE_BUTTONS_UNTIL_FOCUS = False  # NEW - maintain backward compatibility
 DEFAULT_DELETE_NOTES_WITH_ENTITY = True
 DEFAULT_DELETE_NOTES_WITH_DEVICE = True
 DEFAULT_ENABLE_DEVICE_NOTES = True

--- a/custom_components/entity_notes/entity-notes.js
+++ b/custom_components/entity_notes/entity-notes.js
@@ -6,6 +6,7 @@ window.entityNotes = {
     debug: {{DEBUG_LOGGING}},
     maxNoteLength: {{MAX_NOTE_LENGTH}},
     hideButtonsWhenEmpty: {{HIDE_BUTTONS_WHEN_EMPTY}},
+    hideButtonsUntilFocus: {{HIDE_BUTTONS_UNTIL_FOCUS}},
     enableDeviceNotes: {{ENABLE_DEVICE_NOTES}},
 
     // Convenience methods for users
@@ -202,7 +203,8 @@ class EntityNotesCard extends HTMLElement {
         });
 
         textarea.addEventListener('focus', () => {
-            this.autoResize();
+        this.autoResize();
+        this.updateButtonVisibility();
         });
 
         textarea.addEventListener('blur', () => {
@@ -210,8 +212,9 @@ class EntityNotesCard extends HTMLElement {
             // Add a small delay to allow button clicks to register
             setTimeout(() => {
                 if (!this.shadowRoot.activeElement) {
-                    this.switchToViewMode();
+                this.switchToViewMode();
                 }
+                this.updateButtonVisibility();
             }, 200);
         });
 
@@ -235,18 +238,35 @@ class EntityNotesCard extends HTMLElement {
     }
 
     updateButtonVisibility() {
+        const textarea = this.shadowRoot.querySelector('.entity-notes-textarea');
+        const actions = this.shadowRoot.querySelector('.entity-notes-actions');
+        const currentText = textarea.value.trim();
+
+        // NEW LOGIC: Check if hide-until-focus mode is enabled
+        if (window.entityNotes.hideButtonsUntilFocus) {
+            // In hide-until-focus mode, only show buttons when textarea has focus
+            const hasFocus = document.activeElement === textarea ||
+                            this.shadowRoot.activeElement === textarea;
+
+            if (hasFocus) {
+                actions.classList.remove('hidden');
+                debugLog('Entity Notes: Showing buttons (textarea has focus)');
+            } else {
+                actions.classList.add('hidden');
+                debugLog('Entity Notes: Hiding buttons (textarea lost focus)');
+            }
+            return; // Exit early, don't apply other visibility logic
+        }
+
+        // EXISTING LOGIC: Original hide-when-empty behavior
         if (!window.entityNotes.hideButtonsWhenEmpty) {
             debugLog('Entity Notes: Always showing buttons (hideButtonsWhenEmpty is false)');
             return;
         }
 
-        const textarea = this.shadowRoot.querySelector('.entity-notes-textarea');
-        const actions = this.shadowRoot.querySelector('.entity-notes-actions');
-        const currentText = textarea.value.trim();
-        
         // Show buttons if there's text OR if there's an existing note
         const shouldShowButtons = currentText.length > 0 || this.hasExistingNote;
-        
+
         if (shouldShowButtons) {
             actions.classList.remove('hidden');
             debugLog('Entity Notes: Showing buttons (has text or existing note)');
@@ -261,9 +281,9 @@ class EntityNotesCard extends HTMLElement {
         const charCount = this.shadowRoot.querySelector('.entity-notes-char-count');
         const count = textarea.value.length;
         const maxLength = window.entityNotes.maxNoteLength;
-        
+
         charCount.textContent = `${count}/${maxLength}`;
-        
+
         charCount.classList.remove('warning', 'error');
         if (count > maxLength * 0.9) charCount.classList.add('warning');
         if (count >= maxLength) charCount.classList.add('error');
@@ -447,7 +467,7 @@ window.entityNotes.EntityNotesCard = EntityNotesCard;
 
 function findEntityId(dialog) {
     debugLog('Entity Notes: Finding entity ID for dialog');
-    
+
     // Try multiple methods to get entity ID
     const methods = [
         () => dialog.stateObj?.entity_id,
@@ -461,7 +481,7 @@ function findEntityId(dialog) {
             return stateObj?.entity_id;
         }
     ];
-    
+
     for (const method of methods) {
         try {
             const entityId = method();
@@ -473,31 +493,31 @@ function findEntityId(dialog) {
             // Continue to next method
         }
     }
-    
+
     debugLog('Entity Notes: No entity ID found');
     return null;
 }
 
 function injectNotesIntoDialog(dialog) {
     debugLog('Entity Notes: Attempting to inject notes into dialog');
-    
+
     if (!dialog || !dialog.shadowRoot) {
         debugLog('Entity Notes: No dialog or shadowRoot found');
         return;
     }
-    
+
     // Check if already injected
     if (dialog.shadowRoot.querySelector('entity-notes-card')) {
         debugLog('Entity Notes: Notes already injected');
         return;
     }
-    
+
     const entityId = findEntityId(dialog);
     if (!entityId) {
         debugLog('Entity Notes: No entity ID found for dialog');
         return;
     }
-    
+
     // Try multiple selectors to find content area
     const selectors = [
         '.content',
@@ -506,7 +526,7 @@ function injectNotesIntoDialog(dialog) {
         '.dialog-content',
         'ha-dialog-content'
     ];
-    
+
     let contentArea = null;
     for (const selector of selectors) {
         contentArea = dialog.shadowRoot.querySelector(selector);
@@ -515,19 +535,19 @@ function injectNotesIntoDialog(dialog) {
             break;
         }
     }
-    
+
     if (!contentArea) {
         debugLog('Entity Notes: No content area found');
         return;
     }
-    
+
     // Create and inject notes card
     const notesCard = document.createElement('entity-notes-card');
     notesCard.setAttribute('entity-id', entityId);
     contentArea.appendChild(notesCard);
-    
+
     debugLog('Entity Notes: Notes card injected for entity: ' + entityId);
-    
+
     // Load the note after a short delay
     setTimeout(() => {
         notesCard.loadNote();
@@ -680,7 +700,7 @@ function setupDialogObserver() {
         setTimeout(setupDialogObserver, 1000);
         return;
     }
-    
+
     // Observer specifically for Home Assistant shadow DOM
     const observer = new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {
@@ -751,14 +771,14 @@ function setupDialogObserver() {
             });
         });
     });
-    
+
     // Observe the Home Assistant shadow root (where dialogs are actually created)
     debugLog('Entity Notes: Observing home-assistant shadow root');
-    observer.observe(homeAssistant.shadowRoot, { 
-        childList: true, 
-        subtree: true 
+    observer.observe(homeAssistant.shadowRoot, {
+        childList: true,
+        subtree: true
     });
-    
+
     // Also check for existing dialogs in shadow root
     const existingEntityDialogs = homeAssistant.shadowRoot.querySelectorAll('ha-more-info-dialog');
     if (existingEntityDialogs.length > 0) {
@@ -834,14 +854,14 @@ function initializeWithErrorHandling() {
     try {
         debugLog('Entity Notes: Starting initialization...');
         debugLog('Entity Notes: DOM ready state: ' + document.readyState);
-        
+
         initialize();
-        
+
         infoLog('Entity Notes: Initialization completed successfully');
     } catch (error) {
         console.error('Entity Notes: Initialization failed:', error);
         console.error('Entity Notes: Error stack:', error.stack);
-        
+
         // Try fallback initialization after delay
         setTimeout(() => {
             try {

--- a/custom_components/entity_notes/translations/en.json
+++ b/custom_components/entity_notes/translations/en.json
@@ -9,7 +9,8 @@
           "max_note_length": "Maximum note length (50-2000 characters)",
           "auto_backup": "Enable automatic backups",
           "hide_buttons_when_empty": "Hide Save/Delete buttons when no note exists",
-          "delete_notes_with_entity": "Automatically delete notes when entities are removed"
+          "delete_notes_with_entity": "Automatically delete notes when entities are removed",
+          "hide_buttons_until_focus": "Hide buttons unless text area is focused"
         }
       },
       "reconfigure": {
@@ -20,7 +21,8 @@
           "max_note_length": "Maximum note length (50-2000 characters)",
           "auto_backup": "Enable automatic backups",
           "hide_buttons_when_empty": "Hide buttons when no note exists",
-          "delete_notes_with_entity": "Automatically delete notes when entities are removed"
+          "delete_notes_with_entity": "Automatically delete notes when entities are removed",
+          "hide_buttons_until_focus": "Hide buttons unless text area is focused"
         }
       }
     },
@@ -43,7 +45,8 @@
           "max_note_length": "Maximum note length (50-2000 characters)",
           "auto_backup": "Enable automatic backups",
           "hide_buttons_when_empty": "Hide buttons when no note exists",
-          "delete_notes_with_entity": "Automatically delete notes when entities are removed"
+          "delete_notes_with_entity": "Automatically delete notes when entities are removed",
+          "hide_buttons_until_focus": "Hide buttons unless text area is focused"
         }
       }
     },


### PR DESCRIPTION
## Summary
- Adds a new `hide_buttons_until_focus` configuration option that hides Save/Delete buttons until the textarea is focused
- Provides a cleaner, more minimal UI for users who prefer it
- Maintains backward compatibility by defaulting the option to `false`

Closes #25

## Changes
- `const.py`: Added new configuration constant `CONF_HIDE_BUTTONS_UNTIL_FOCUS`
- `__init__.py`: Added support for reading and passing the new option to the frontend
- `config_flow.py`: Added the new option to all config flow forms
- `entity-notes.js`: Implemented the hide-until-focus logic in `updateButtonVisibility()`
- `translations/en.json`: Added translation string for the new option
