### PR TITLE
fix: Prevent markdown toolbar reappearing below note after save

### DIFF
--- a/custom_components/entity_notes/entity-notes.js
+++ b/custom_components/entity_notes/entity-notes.js
@@ -1003,6 +1003,16 @@ class EntityNotesCard extends HTMLElement {
     updateEditControlsVisibility() {
         const editControls = this.shadowRoot.querySelector('.entity-notes-edit-controls');
         const markdownToolbar = this.shadowRoot.querySelector('.entity-notes-markdown-toolbar');
+
+        // In view mode (rendered note visible) keep the toolbar hidden regardless of other settings.
+        // The blur handler always calls this, which would otherwise re-show the toolbar below the note.
+        const viewDiv = this.shadowRoot.querySelector('.entity-notes-view');
+        if (!viewDiv.classList.contains('hidden')) {
+            editControls.classList.add('hidden');
+            markdownToolbar.classList.add('hidden');
+            return;
+        }
+
         const shouldShowMarkdownToolbar = window.entityNotes.showMarkdownToolbar === true ||
             window.entityNotes.showMarkdownToolbar === 'true';
         const shouldHideUntilFocus = window.entityNotes.hideMarkdownHints === true ||


### PR DESCRIPTION
## Summary

- After saving a note, `switchToViewMode()` correctly hides the edit controls, but the textarea `blur` event fires shortly after and unconditionally calls `updateEditControlsVisibility()`
- With the default `hideMarkdownHints = false` setting, that function computed `shouldShowEditControls = true` and re-showed the toolbar
- Because the rendered note view has CSS `order: 1` and the edit-controls have `order: 2` in the flexbox, the toolbar appeared **below** the note instead of above the textarea
- Fix: guard `updateEditControlsVisibility()` so it forces the controls hidden whenever the rendered note view div is visible (i.e. we're in view mode)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Bf6kfz4VCif22v4jWR7R)_